### PR TITLE
feat: export wallet types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4179,6 +4179,7 @@ dependencies = [
  "serde_json",
  "sov-accounts",
  "sov-bank",
+ "sov-mock-da",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-rollup-interface",

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2041,6 +2041,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sov-mock-da"
+version = "0.3.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=84ed498393577fd1272338599639eb57340c5b89#84ed498393577fd1272338599639eb57340c5b89"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "borsh",
+ "bytes",
+ "hex",
+ "serde",
+ "sha2 0.10.8",
+ "sov-rollup-interface",
+]
+
+[[package]]
 name = "sov-modules-api"
 version = "0.3.0"
 source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=84ed498393577fd1272338599639eb57340c5b89#84ed498393577fd1272338599639eb57340c5b89"
@@ -2223,6 +2238,7 @@ dependencies = [
  "serde",
  "sov-accounts",
  "sov-bank",
+ "sov-mock-da",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-rollup-interface",

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -1147,6 +1147,7 @@ dependencies = [
  "serde",
  "sov-accounts",
  "sov-bank",
+ "sov-mock-da",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-rollup-interface",

--- a/crates/stf/Cargo.toml
+++ b/crates/stf/Cargo.toml
@@ -14,6 +14,7 @@ sov-state = { workspace = true }
 sov-accounts = { workspace = true }
 sov-bank = { workspace = true }
 sov-sequencer-registry = { workspace = true }
+sov-mock-da = { workspace = true }
 sov-modules-stf-blueprint = { workspace = true }
 sov-stf-runner = { workspace = true }
 sov-sequencer = { workspace = true, optional = true }
@@ -31,16 +32,23 @@ clap = { workspace = true, features = ["derive"], optional = true }
 
 
 [features]
-default = []
+default = ["serde"]
 native = [
     "sov-modules-api/native",
     "sov-accounts/native",
     "sov-bank/native",
     "sov-sequencer-registry/native",
+    "sov-mock-da/native",
     "sov-modules-stf-blueprint/native",
     "sov-stf-runner/native",
     "serde_json",
     "jsonrpsee",
     "sov-sequencer",
     "clap",
+]
+serde = [
+    "sov-accounts/serde",
+    "sov-bank/serde",
+    "sov-modules-api/serde",
+    "sov-sequencer-registry/serde",
 ]

--- a/crates/stf/Cargo.toml
+++ b/crates/stf/Cargo.toml
@@ -45,6 +45,7 @@ native = [
     "jsonrpsee",
     "sov-sequencer",
     "clap",
+    "serde",
 ]
 serde = [
     "sov-accounts/serde",

--- a/crates/stf/src/lib.rs
+++ b/crates/stf/src/lib.rs
@@ -12,3 +12,5 @@ use sov_stf_runner::verifier::StateTransitionVerifier;
 /// Alias for StateTransitionVerifier.
 pub type StfVerifier<DA, Vm, ZkContext, RT, K> =
     StateTransitionVerifier<StfBlueprint<ZkContext, <DA as DaVerifier>::Spec, Vm, RT, K>, DA, Vm>;
+
+pub use sov_mock_da::MockDaSpec;

--- a/crates/stf/src/runtime.rs
+++ b/crates/stf/src/runtime.rs
@@ -57,10 +57,7 @@ use crate::genesis_config::GenesisPaths;
 )]
 #[derive(Genesis, DispatchCall, MessageCodec, DefaultRuntime)]
 #[serialization(borsh::BorshDeserialize, borsh::BorshSerialize)]
-#[cfg_attr(
-    feature = "native",
-    serialization(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", serialization(serde::Serialize, serde::Deserialize))]
 pub struct Runtime<C: Context, Da: DaSpec> {
     /// The `accounts` module is responsible for managing user accounts and their nonces
     pub accounts: sov_accounts::Accounts<C>,


### PR DESCRIPTION
This commit re-exports the types required for a wallet interface, and also requires `serde` for the `crates/rollup/stf` outside native as it will be needed for JSON runtime call deserialization.