### PR TITLE
Update sov-rollup-starter with latest changes from nightly - archival rpc support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3769,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3813,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3830,7 +3830,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3847,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-rpc"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "futures",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3880,7 +3880,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3907,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-core"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3926,7 +3926,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3965,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3976,6 +3976,7 @@ dependencies = [
  "sov-blob-storage",
  "sov-chain-state",
  "sov-modules-api",
+ "sov-modules-core",
  "sov-rollup-interface",
  "sov-state",
  "thiserror",
@@ -3985,7 +3986,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-storage-manager"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "sov-db",
@@ -3998,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4015,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4070,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "sov-schema-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -4083,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4099,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4116,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4135,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4158,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "sov-zk-cycle-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "bytes",
  "risc0-zkvm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,24 +16,24 @@ publish = false
 rust-version = "1.73"
 
 [workspace.dependencies]
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-ledger-rpc = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-first-read-last-write-cache = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-prover-storage-manager = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-ledger-rpc = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-first-read-last-write-cache = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-prover-storage-manager = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
 
 stf-starter = { path = "./crates/stf" }
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ make test-bank-supply-of
 #### 7. The output of the above script:
 
 ```bash,test-ci,bashtestmd:compare-output
-$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"bank_supplyOf","params":["sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"],"id":1}' http://127.0.0.1:12345
+$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"bank_supplyOf","params":{"token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"},"id":1}' http://127.0.0.1:12345
 {"jsonrpc":"2.0","result":{"amount":1000},"id":1}
 ```
 
@@ -96,6 +96,6 @@ $ make test-bank-supply-of
 #### 7. The output of the above script:
 
 ```
-$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"bank_supplyOf","params":["sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"],"id":1}' http://127.0.0.1:12345
+$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"bank_supplyOf","params":{"token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"},"id":1}' http://127.0.0.1:12345
 {"jsonrpc":"2.0","result":{"amount":1000},"id":1}
 ```

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2018,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2031,7 +2031,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2071,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2099,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2115,7 +2115,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2136,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-core"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2155,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2170,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2180,6 +2180,7 @@ dependencies = [
  "sov-blob-storage",
  "sov-chain-state",
  "sov-modules-api",
+ "sov-modules-core",
  "sov-rollup-interface",
  "sov-state",
  "thiserror",
@@ -2189,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2204,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2221,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2234,7 +2235,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bcs",
@@ -2252,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2266,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "sov-zk-cycle-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "bytes",
  "risc0-zkvm",

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -13,12 +13,12 @@ risc0-zkvm-platform = "0.19"
 
 stf-starter = { path = "../../../stf" }
 
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
 
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2/v0.10.6-risc0" }

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -993,7 +993,7 @@ checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1006,7 +1006,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1019,7 +1019,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1035,7 +1035,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-core"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1103,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1128,6 +1128,7 @@ dependencies = [
  "sov-blob-storage",
  "sov-chain-state",
  "sov-modules-api",
+ "sov-modules-core",
  "sov-rollup-interface",
  "sov-state",
  "thiserror",
@@ -1137,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1152,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1169,7 +1170,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1182,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "bcs",
@@ -1200,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1214,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "sov-zk-cycle-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=de526a6bafeccb982a7e19a5abe7ca8997f58240#de526a6bafeccb982a7e19a5abe7ca8997f58240"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=a8a234c0d1a6e2b45f5e2852d0846a97c6a00133#a8a234c0d1a6e2b45f5e2852d0846a97c6a00133"
 dependencies = [
  "bytes",
  "risc0-zkvm",

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -14,12 +14,12 @@ risc0-zkvm-platform = "0.19"
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "de526a6bafeccb982a7e19a5abe7ca8997f58240" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "a8a234c0d1a6e2b45f5e2852d0846a97c6a00133" }
 
 stf-starter = { path = "../../../stf" }
 

--- a/crates/rollup/Makefile
+++ b/crates/rollup/Makefile
@@ -104,5 +104,5 @@ test-create-token: set-rpc-url test-generate-create-token-tx import-keys
 
 
 test-bank-supply-of: 
-	curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"bank_supplyOf","params":["sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"],"id":1}' http://127.0.0.1:12345
+	curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"bank_supplyOf","params":{"token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"},"id":1}' http://127.0.0.1:12345
 

--- a/crates/rollup/tests/bank/mod.rs
+++ b/crates/rollup/tests/bank/mod.rs
@@ -95,6 +95,7 @@ async fn send_test_create_token_tx(rpc_address: SocketAddr) -> Result<(), anyhow
 
     let balance_response = sov_bank::BankRpcClient::<DefaultContext>::balance_of(
         client.http(),
+        None,
         user_address,
         token_address,
     )

--- a/sov-rollup-starter.sh
+++ b/sov-rollup-starter.sh
@@ -33,9 +33,9 @@ if [ $? -ne 0 ]; then
     echo "Expected exit code 0, got $?"
     exit 1
 fi
-echo 'Running: '\''curl -X POST -H "Content-Type: application/json" -d '\''{"jsonrpc":"2.0","method":"bank_supplyOf","params":["sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"],"id":1}'\'' http://127.0.0.1:12345'\'''
+echo 'Running: '\''curl -X POST -H "Content-Type: application/json" -d '\''{"jsonrpc":"2.0","method":"bank_supplyOf","params":{"token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"},"id":1}'\'' http://127.0.0.1:12345'\'''
 
-output=$(curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"bank_supplyOf","params":["sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"],"id":1}' http://127.0.0.1:12345)
+output=$(curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"bank_supplyOf","params":{"token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"},"id":1}' http://127.0.0.1:12345)
 expected='{"jsonrpc":"2.0","result":{"amount":1000},"id":1}
 '
 # Either of the two must be a substring of the other. This kinda protects us


### PR DESCRIPTION
## Description
sovereign-sdk repo was updated to support archival queries using `Version`. RPC in the bank module was updated to have `version: u64` as an argument for `balanceOf` and `supplyOf`, so sov-rollup-starter has the commit as well as the Makefile commands updated

```
{"jsonrpc":"2.0","method":"bank_supplyOf",
"params":["sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"],
"id":1}
```
is updated to 
```
{"jsonrpc":"2.0","method":"bank_supplyOf",
"params":{"token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"},
"id":1}
```
When dictionary is used, version does not need to be specified